### PR TITLE
chore: update protobuf dependency version to 6.33.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dsis-schemas"
-version = "0.0.5"
+version = "0.0.6"
 description = "Python SDK for DSIS OpenWorks Common Model and OW5000 Native Model schemas"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
update protobuf version to 6.33.1 to be compatible with new horizondata_3D version