### PR TITLE
fix: read all messages in length-delimited protobuf

### DIFF
--- a/dsis_model_sdk/protobuf/__init__.py
+++ b/dsis_model_sdk/protobuf/__init__.py
@@ -34,6 +34,7 @@ Note:
     The protobuf package is optional. Install with:
     pip install dsis-schemas[protobuf]
 """
+from typing import Tuple, TypeVar
 
 # Import generated protobuf modules
 try:
@@ -69,6 +70,84 @@ except ImportError as e:
     _import_error = str(e)
 
 
+
+def _decode_varint(data: bytes, offset: int) -> Tuple[int, int]:
+    """Decode a varint to find the size of the subsequent message and the offset where it starts.
+
+    A varint is a variable-length encoding for integers used in protobuf to record the size of the subsequent message.
+
+    Each byte of the varint  has the most significant bit (MSB) as a continuation flag.
+    The remaining 7 bits of each byte contribute to the integer value.
+    The varint ends when a byte with MSB=0 is encountered (meaning no continuation).
+
+    Returns:
+    (message_size, message_start): the message size (decoded int value) and the byte offset where it starts (after the decoded int)
+
+    Raises:
+    ValueError: If the varint is malformed or exceeds expected length
+    """
+    result = 0
+    shift = 0
+    while True:
+        if offset >= len(data):
+            raise ValueError("Unexpected end of data while decoding varint.")
+        byte = data[offset]
+        result |= (byte & 0x7F) << shift
+        offset += 1
+        if not (byte & 0x80):
+            return result, offset
+        shift += 7
+        if shift > 64:
+            raise ValueError("Varint is too long, possible overflow or malformed data.")
+
+# All protobuf messages (such as LGCStructure, HorizonData3D, etc.) inherit from google.protobuf.message.Message
+# With this, we bind that to a generic type _M so when a specific subbclass of Message is used, the type hinting
+# will know which one it is and provide better autocompletion and type checking.
+try:
+    from google.protobuf.message import Message as _PbMessage
+    _M = TypeVar('_M', bound=_PbMessage)
+except ImportError:
+    _M = TypeVar('_M')  # type: ignore[misc]
+
+
+def _decode_length_delimited_protobuf(input_binary: bytes, target_protobuf: _M) -> _M:  # type: ignore[return]
+    """
+    Decode one or more length-delimited protobuf messages
+
+    DSIS returns bulk protobuf payloads as lenght-delimited streams: a series of one or more messages,
+    where each message is prefixed by a varint indicating its size, followed by the message bytes.
+    This function reads all the messages in a payload, merging them into a single message.
+
+    Args:
+        input_binary: The raw bytes as received from the API.
+        target_protobuf: A pre-instantiated (empty) object of any protobuf type (e.g. LGCStructure, HorizonData3D, etc.)
+        Important: the object is modified in place and returned for convenience, but the caller can also
+        just use the modified object without relying on the return value.
+
+    Returns:
+        The same target_protobuf object, now populated with the decoded data. 
+
+    Raises:
+        ValueError: If a varint is malformed or data is truncated.
+
+    Example:
+        >>> lgc_structure = LGCStructure_pb2.LGCStructure()
+        >>> lgc_structure = _decode_length_delimited_protobuf(binary_data, lgc_structure)
+    """
+    offset = 0
+    msg_count = 0
+    while offset < len(input_binary):
+        msg_size, msg_start = _decode_varint(input_binary, offset) # Read and decode the size of the next message
+        msg_binary = input_binary[msg_start:msg_start + msg_size]  # Extract the actual message bytes
+        if msg_count == 0:
+            target_protobuf.ParseFromString(msg_binary)            # First message goes into empty buffer
+        else:
+            target_protobuf.MergeFromString(msg_binary)            # Subsequent messages are appended
+        offset = msg_start + msg_size
+        msg_count += 1
+    return target_protobuf
+
+
 # Helper function for length-prefixed messages
 def _skip_varint_length_prefix(binary_data: bytes) -> bytes:
     """
@@ -76,6 +155,10 @@ def _skip_varint_length_prefix(binary_data: bytes) -> bytes:
     
     This is commonly used when protobuf messages are stored in files or
     transmitted over streams where message boundaries need to be defined.
+
+    This method assumes the whole message is contained in a single length-prefixed block.
+    If multiple messages are concatenated, use _decode_varint in a loop to read each message
+    sequentially and keep track of the offset to the next one.
     
     Args:
         binary_data: Binary data with varint length prefix
@@ -83,19 +166,9 @@ def _skip_varint_length_prefix(binary_data: bytes) -> bytes:
     Returns:
         Binary data without the length prefix
     """
-    result = 0
-    shift = 0
-    offset = 0
-    while offset < len(binary_data):
-        byte = binary_data[offset]
-        result |= (byte & 0x7f) << shift
-        offset += 1
-        if not (byte & 0x80):
-            break
-        shift += 7
+    (message_size, offset) = _decode_varint(binary_data, 0)
     # Return only the message bytes (using length for boundary)
-    return binary_data[offset:offset + result]
-
+    return binary_data[offset:offset + message_size]
 
 # Decoder functions
 def decode_horizon_data(binary_data: bytes, skip_length_prefix: bool = False) -> 'HorizonData3D_pb2.HorizonData3D':
@@ -267,13 +340,17 @@ def decode_array_2f(binary_data: bytes) -> 'Array2FBuf_pb2.Array2FBuf':
     return message
 
 
-def decode_lgc_structure(binary_data: bytes, skip_length_prefix: bool = False) -> 'LGCStructure_pb2.LGCStructure':
+def decode_lgc_structure(binary_data: bytes) -> 'LGCStructure_pb2.LGCStructure': # type: ignore[name-defined]
     """
     Decode binary tabular data into structured LGCStructure protobuf message.
+
+    The payload is a length-delimited protobuf stream: one or more
+    concatenated messages, each prefixed by a varint indicating its size.
+    The first message initialises the structure; subsequent messages are
+    merged to build the complete table.
     
     Args:
-        binary_data: Binary bytes containing tabular data
-        skip_length_prefix: If True, skips varint length prefix (for file storage)
+        binary_data: Binary bytes containing tabular data (length-delimited)
         
     Returns:
         LGCStructure protobuf message with decoded tabular structure
@@ -285,21 +362,15 @@ def decode_lgc_structure(binary_data: bytes, skip_length_prefix: bool = False) -
     Example:
         >>> from dsis_model_sdk.protobuf import decode_lgc_structure
         >>> 
-        >>> # Decode with length prefix (common in file storage)
-        >>> decoded = decode_lgc_structure(file_data, skip_length_prefix=True)
-        >>> 
-        >>> # Access structure
+        >>> decoded = decode_lgc_structure(raw_bytes)
         >>> print(f"Structure: {decoded.structName}")
         >>> for element in decoded.elements:
         ...     print(f"Element: {element.elementName}, Type: {element.dataType}")
     """
     _check_protobuf_available()
-    if skip_length_prefix:
-        binary_data = _skip_varint_length_prefix(binary_data)
-    message = LGCStructure_pb2.LGCStructure()
-    message.ParseFromString(binary_data)
+    message = LGCStructure_pb2.LGCStructure() # type: ignore[attr-defined]
+    _decode_length_delimited_protobuf(binary_data, message)
     return message
-
 
 def decode_fault_plane(binary_data: bytes) -> 'FaultPlane_pb2.FaultPlane':
     """

--- a/dsis_model_sdk/protobuf/__init__.py
+++ b/dsis_model_sdk/protobuf/__init__.py
@@ -148,28 +148,6 @@ def _decode_length_delimited_protobuf(input_binary: bytes, target_protobuf: _M) 
     return target_protobuf
 
 
-# Helper function for length-prefixed messages
-def _skip_varint_length_prefix(binary_data: bytes) -> bytes:
-    """
-    Skip varint length prefix and return the actual message bytes.
-    
-    This is commonly used when protobuf messages are stored in files or
-    transmitted over streams where message boundaries need to be defined.
-
-    This method assumes the whole message is contained in a single length-prefixed block.
-    If multiple messages are concatenated, use _decode_varint in a loop to read each message
-    sequentially and keep track of the offset to the next one.
-    
-    Args:
-        binary_data: Binary data with varint length prefix
-        
-    Returns:
-        Binary data without the length prefix
-    """
-    (message_size, offset) = _decode_varint(binary_data, 0)
-    # Return only the message bytes (using length for boundary)
-    return binary_data[offset:offset + message_size]
-
 # Decoder functions
 def decode_horizon_data(binary_data: bytes, skip_length_prefix: bool = False) -> 'HorizonData3D_pb2.HorizonData3D':
     """
@@ -210,10 +188,11 @@ def decode_horizon_data(binary_data: bytes, skip_length_prefix: bool = False) ->
         ...         print(f"Sample {i}: col={col}, row={row}, z={val}")
     """
     _check_protobuf_available()
+    message = HorizonData3D_pb2.HorizonData3D() # type: ignore[attr-defined]
     if skip_length_prefix:
-        binary_data = _skip_varint_length_prefix(binary_data)
-    message = HorizonData3D_pb2.HorizonData3D()
-    message.ParseFromString(binary_data)
+        _decode_length_delimited_protobuf(binary_data, message)
+    else:
+        message.ParseFromString(binary_data)
     return message
 
 
@@ -285,10 +264,11 @@ def decode_seismic_data(binary_data: bytes, skip_length_prefix: bool = False) ->
         ...     print(f"Short data: {len(decoded.data.data_short)} values")
     """
     _check_protobuf_available()
+    message = SeismicData_pb2.SeismicData() # type: ignore[attr-defined]
     if skip_length_prefix:
-        binary_data = _skip_varint_length_prefix(binary_data)
-    message = SeismicData_pb2.SeismicData()
-    message.ParseFromString(binary_data)
+        _decode_length_delimited_protobuf(binary_data, message)
+    else:
+        message.ParseFromString(binary_data)
     return message
 
 
@@ -313,10 +293,11 @@ def decode_array_3f(binary_data: bytes, skip_length_prefix: bool = False) -> 'Ar
         >>> print(f"Data points: {len(decoded.data)}")
     """
     _check_protobuf_available()
+    message = Array3FBuf_pb2.Array3FBuf() # type: ignore[attr-defined]
     if skip_length_prefix:
-        binary_data = _skip_varint_length_prefix(binary_data)
-    message = Array3FBuf_pb2.Array3FBuf()
-    message.ParseFromString(binary_data)
+        _decode_length_delimited_protobuf(binary_data, message)
+    else:
+        message.ParseFromString(binary_data)
     return message
 
 
@@ -448,10 +429,11 @@ def decode_property_table_set(binary_data: bytes, skip_length_prefix: bool = Fal
         Exception: If binary data is invalid or corrupted
     """
     _check_protobuf_available()
+    message = PropertyTableSet_pb2.PropertyTableSet() # type: ignore[attr-defined]
     if skip_length_prefix:
-        binary_data = _skip_varint_length_prefix(binary_data)
-    message = PropertyTableSet_pb2.PropertyTableSet()
-    message.ParseFromString(binary_data)
+        _decode_length_delimited_protobuf(binary_data, message)
+    else:
+        message.ParseFromString(binary_data)
     return message
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dsis-schemas"
-version = "0.0.6"
+version = "0.0.7"
 description = "Python SDK for DSIS OpenWorks Common Model and OW5000 Native Model schemas"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
We found [a bug](https://github.com/equinor/dsis-schemas/issues/5) in decoding the protobuf for LGCStructure where the objects appeared truncated (returned only the first columns of the tabular data and then stopped). Upon inspection, the reason for that was that the method _skip_varint_length_prefix was reading only the first message and then stopping.

For larger objects with repeated elements such as the tabular LGC, horizons, or seismic data, DSIS uses protobuf length-delimited streaming - a standard pattern when the data is too large for a single protobuf message, or when the server produces data incrementally. The binary blob in this case looks like:

[varint: length₁][message₁ bytes][varint: length₂][message₂ bytes][varint: length₃][message₃ bytes]...

Each chunk in this case is a valid protobuf message containing some of the elements. When using `MergeFromString` the repeated fields (like [elements] in LGCStructure) accumulate, giving you the complete object. 

This is why small grids (one message) worked fine with the SDK, but larger grids (multiple messages) get truncated.

--

With the change on this PR, LGCStructure and all other protobuf types that were using the _skip_varint_length_prefix (assumed to be all types that support length-delimited streaming) will read all of the messages from the binary data and combine them to return the full decoded object. 

For that, we replace the _skip_varint_length_prefix function, which only skipped one var int and returned the contents of the one message it referred, by the _decode_length_delimited_protobuf function, which instead reads all messages until the binary stream is empty.

This function is also aided by a TypeVar definition, which binds the input/output type to a generic type _M  that covers all subtypes of google.protobuf.message.Message (which have the methos ParseFromString, MergeFromString), so the type hinting will know which one to use and provide better autocompletion and type checking.

--

Notes for review:

- The function didn't have to return the target protobuf, as it is mutated in place to include the contents. The caller functions are not using the return, rather depending on the value being mutated just like they do when doing message.ParseFromString. However, the value is returned to facilitate for callers who want to do chaining on the object.

- For LGCStructure, we always have a length-delimited protobuf, so the option to choose whether to read it as a single message (without skipping the varint) was removed. For the other types, I wasn't sure, so left the option there and the user can control whether to read it as a simple message or a length-delimited protobuf. I am open to remove the option from those if we know they are always length-delimited or, on the contrary, reintroduce the option on the LGCStructure if it is indeed something Landmark offers as an option.