### PR TITLE
chore: drop support for Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install -e .
 
 ### Dependencies
 
-- Python 3.8+
+- Python 3.9+
 - Pydantic 2.0+
 - typing-extensions 4.0+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,16 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "pydantic>=2.0.0,<3.0.0",
     "typing-extensions>=4.0.0",
@@ -103,7 +104,7 @@ use_parentheses = true
 ensure_newline_before_comments = true
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
Drops support for Python 3.8. Also makes 3.12 (current LTS) the default for mypy checks and documents 3.13 and 3.14 as also supported.

Reason:

- The updated version of protobuf introduced in [#1](https://github.com/equinor/dsis-schemas/pull/1) broke the environment, as there is no version of protobuf > 6.33 that supports Python 3.8, making it impossible to create a venv based on the existing pyproject.toml

- Python 3.8 (and also 3.9) have already reached end of life and are no longer supported - https://devguide.python.org/versions/