### PR TITLE
chore: bump version to 0.0.9 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dsis-schemas"
-version = "0.0.8"
+version = "0.0.9"
 description = "Python SDK for DSIS OpenWorks Common Model and OW5000 Native Model schemas"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
This pull request updates the version of the `dsis-schemas` package from `0.0.8` to `0.0.9` in `pyproject.toml`. This is a standard version bump, typically used to indicate a new release with bug fixes or minor improvements.